### PR TITLE
Added support for additional distro´s

### DIFF
--- a/configurer/linux/enterpriselinux/almalinux.go
+++ b/configurer/linux/enterpriselinux/almalinux.go
@@ -1,0 +1,25 @@
+package enterpriselinux
+
+import (
+	"github.com/k0sproject/k0sctl/configurer"
+	k0slinux "github.com/k0sproject/k0sctl/configurer/linux"
+	"github.com/k0sproject/rig"
+	"github.com/k0sproject/rig/os/registry"
+)
+
+// AlmaLinux provides OS support for AlmaLinux
+type AlmaLinux struct {
+	k0slinux.EnterpriseLinux
+	configurer.Linux
+}
+
+func init() {
+	registry.RegisterOSModule(
+		func(os rig.OSVersion) bool {
+			return os.ID == "almalinux"
+		},
+		func() interface{} {
+			return AlmaLinux{}
+		},
+	)
+}

--- a/configurer/linux/enterpriselinux/rocky.go
+++ b/configurer/linux/enterpriselinux/rocky.go
@@ -1,0 +1,25 @@
+package enterpriselinux
+
+import (
+	"github.com/k0sproject/k0sctl/configurer"
+	k0slinux "github.com/k0sproject/k0sctl/configurer/linux"
+	"github.com/k0sproject/rig"
+	"github.com/k0sproject/rig/os/registry"
+)
+
+// RockyLinux provides OS support for RockyLinux
+type RockyLinux struct {
+	k0slinux.EnterpriseLinux
+	configurer.Linux
+}
+
+func init() {
+	registry.RegisterOSModule(
+		func(os rig.OSVersion) bool {
+			return os.ID == "rocky"
+		},
+		func() interface{} {
+			return RockyLinux{}
+		},
+	)
+}


### PR DESCRIPTION
name: Go

on:
  push:
    branches-ignore:
      - "main"
  pull_request:

jobs:

  build:
    runs-on: ubuntu-latest
    steps:
    - uses: actions/checkout@v2

    - name: Set up Go
      uses: actions/setup-go@v2
      with:
        go-version: 1.16

    - name: Go modules cache
      uses: actions/cache@v2
      with:
        path: |
          ~/go/pkg/mod
          ~/.cache/go-build
          ~/Library/Caches/go-build
          %LocalAppData%\go-build
        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
        restore-keys: |
          ${{ runner.os }}-go-

    - name: Run golangci-lint
      uses: golangci/golangci-lint-action@v2.3.0
      with:
        version: v1.35.2

    - name: Build
      run: make k0sctl

    - name: Test
      run: go test -v ./...

    - name: Cache the compiled binary for further testing
      uses: actions/cache@v2
      id: cache-compiled-binary
      with:
        path: |
          k0sctl
        key: build-${{ github.run_id }}

    - name: Build windows
      run: make bin/k0sctl-win-x64.exe

  smoke-basic:
    strategy:
      matrix:
        image:
          - quay.io/footloose/ubuntu18.04
          - quay.io/footloose/centos7
            #- quay.io/footloose/amazonlinux2
          - quay.io/footloose/debian10
          - quay.io/footloose/fedora29
    name: Basic 1+1 smoke
    needs: build
    runs-on: ubuntu-latest

    steps:
      - name: Check out code into the Go module directory
        uses: actions/checkout@v2

      - name: Set up Go
        uses: actions/setup-go@v2
        with:
          go-version: 1.16

      - name: Restore the compiled binary for smoke testing
        uses: actions/cache@v2
        id: restore-compiled-binary
        with:
          path: |
            k0sctl
          key: build-${{ github.run_id }}

      - name: K0sctl cache
        uses: actions/cache@v2
        with:
          path: |
            /var/cache/k0sctl
            ~/.k0sctl/cache
            !*.log
          key: k0sctl-cache

      - name: Docker Layer Caching For Footloose
        uses: satackey/action-docker-layer-caching@v0.0.11
        continue-on-error: true

      - name: Run smoke tests
        env:
          LINUX_IMAGE: ${{ matrix.image }}
        run: make smoke-basic

  smoke-os-override:
    name: OS override smoke test
    needs: build
    runs-on: ubuntu-latest

    steps:
      - name: Check out code into the Go module directory
        uses: actions/checkout@v2

      - name: Set up Go
        uses: actions/setup-go@v2
        with:
          go-version: 1.16

      - name: Restore the compiled binary for smoke testing
        uses: actions/cache@v2
        id: restore-compiled-binary
        with:
          path: |
            k0sctl
          key: build-${{ github.run_id }}

      - name: K0sctl cache
        uses: actions/cache@v2
        with:
          path: |
            /var/cache/k0sctl
            ~/.k0sctl/cache
            !*.log
          key: k0sctl-cache

      - name: Docker Layer Caching For Footloose
        uses: satackey/action-docker-layer-caching@v0.0.11
        continue-on-error: true

      - name: Run OS override smoke test
        run: make smoke-os-override

  smoke-upgrade:
    strategy:
      matrix:
        image:
          - quay.io/footloose/ubuntu18.04
          - quay.io/footloose/centos7
          #- quay.io/footloose/amazonlinux2
          #- quay.io/footloose/debian10
          #- quay.io/footloose/fedora29
    name: Upgrade 0.10 --> 0.11
    needs: build
    runs-on: ubuntu-latest

    steps:
      - name: Check out code into the Go module directory
        uses: actions/checkout@v2

      - name: Set up Go
        uses: actions/setup-go@v2
        with:
          go-version: 1.16

      - name: Restore the compiled binary for smoke testing
        uses: actions/cache@v2
        id: restore-compiled-binary
        with:
          path: |
            k0sctl
          key: build-${{ github.run_id }}

      - name: K0sctl cache
        uses: actions/cache@v2
        with:
          path: |
            /var/cache/k0sctl
            ~/.k0sctl/cache
            !*.log
          key: k0sctl-cache

      - name: Old k0sctl cache
        uses: actions/cache@v2
        with:
          path: |
            ~/.cache
          key: k0sctl-040-cache

      - name: Docker Layer Caching For Footloose
        uses: satackey/action-docker-layer-caching@v0.0.11
        continue-on-error: true

      - name: Run smoke tests
        env:
          LINUX_IMAGE: ${{ matrix.image }}
        run: make smoke-upgrade

  smoke-reset:
    strategy:
      matrix:
        image:
          - quay.io/footloose/ubuntu18.04
          - quay.io/footloose/centos7
    name: Apply + reset
    needs: build
    runs-on: ubuntu-latest

    steps:
      - name: Check out code into the Go module directory
        uses: actions/checkout@v2
      - name: Set up Go
        uses: actions/setup-go@v2
        with:
          go-version: 1.16

      - name: Restore compiled binary for smoke testing
        uses: actions/cache@v2
        id: restore-compiled-binary
        with:
          path: |
            k0sctl
          key: build-${{ github.run_id }}

      - name: Run smoke tests
        env:
          LINUX_IMAGE: ${{ matrix.image }}
        run: make smoke-reset

  smoke-backup-restore:
    strategy:
      matrix:
        image:
          - quay.io/footloose/ubuntu18.04
          - quay.io/footloose/centos7
    name: Apply + backup + reset + restore
    needs: build
    runs-on: ubuntu-latest

    steps:
      - name: Check out code into the Go module directory
        uses: actions/checkout@v2
      - name: Set up Go
        uses: actions/setup-go@v2
        with:
          go-version: 1.16

      - name: Restore compiled binary for smoke testing
        uses: actions/cache@v2
        id: restore-compiled-binary
        with:
          path: |
            k0sctl
          key: build-${{ github.run_id }}

      - name: Run smoke tests
        env:
          LINUX_IMAGE: ${{ matrix.image }}
        run: make smoke-backup-restore

  smoke-init:
    name: Init sub-command smoke test
    needs: build
    runs-on: ubuntu-latest

    steps:
      - name: Check out code into the Go module directory
        uses: actions/checkout@v2

      - name: Set up Go
        uses: actions/setup-go@v2
        with:
          go-version: 1.16

      - name: Restore the compiled binary for smoke testing
        uses: actions/cache@v2
        id: restore-compiled-binary
        with:
          path: |
            k0sctl
          key: build-${{ github.run_id }}

      - name: K0sctl cache
        uses: actions/cache@v2
        with:
          path: |
            /var/cache/k0sctl
            ~/.k0sctl/cache
            !*.log
          key: k0sctl-cache

      - name: Docker Layer Caching For Footloose
        uses: satackey/action-docker-layer-caching@v0.0.11
        continue-on-error: true

      - name: Run init smoke test
        run: make smoke-init
